### PR TITLE
Continue processing PDFs on error

### DIFF
--- a/models/PdfTextProcess.php
+++ b/models/PdfTextProcess.php
@@ -36,11 +36,12 @@ class PdfTextProcess extends Omeka_Job_AbstractJob
                 $file->deleteElementTextsByElementId(array($textElement->id));
 
                 // Extract the PDF text and add it to the file.
-                $file->addTextForElement(
-                    $textElement,
-                    $pdfTextPlugin->pdfToText(FILES_DIR . '/original/' . $file->filename)
-                );
-                $file->save();
+                $filepath = FILES_DIR . '/original/' . $file->filename;
+                $text = $pdfTextPlugin->pdfToText($filepath);
+                if (isset($text)) {
+                    $file->addTextForElement($textElement, $text);
+                    $file->save();
+                }
 
                 // Prevent memory leaks.
                 release_object($file);


### PR DESCRIPTION
When pdftotext fails to extract text from a PDF, PdfTextPlugin::pdfToText
returns NULL and the whole process stops because NULL is not allowed in
element_texts.text.
This patch allows the process to continue after pdftotext errors.